### PR TITLE
Drop HAVE_DRM compilation option

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -27,8 +27,7 @@ sha256sums=(
 
 build() {
   cmake -S mpp -B build \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DHAVE_DRM=ON
+    -DCMAKE_BUILD_TYPE=Release
   cmake --build build
 }
 


### PR DESCRIPTION
Upstream has removed the option:

https://github.com/rockchip-linux/mpp/commit/318bfc1b783831424529d483ef74baadc7478807