### PR TITLE
Remove SystemD dependency, for non-systemd systems

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -8,7 +8,7 @@ pkgdesc='Rockchip VPU Media Process Platform (MPP) for hardware video decode lat
 arch=('x86_64' 'aarch64' 'arm7h')
 url='https://github.com/rockchip-linux/mpp'
 license=('Apache')
-depends=('gcc-libs' 'coreutils' 'systemd')
+depends=('gcc-libs' 'coreutils' 'udev')
 makedepends=('cmake')
 provides=({rockchip-,}mpp="${pkgver}")
 conflicts=({rockchip-,}mpp)


### PR DESCRIPTION
Replaced SystemD dependency with udev, as systemd provides udev on systemd systems, and eudev provides udev on non-systemd systems.